### PR TITLE
Update LICENSE to reflect Pocket MIT license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,14 +1,11 @@
-
-This style guide is available under the MIT license:
-
-Copyright (c) 2016-2018 Razeware LLC
+Copyright 2012-2019 Read It Later, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+ furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.

--- a/README.markdown
+++ b/README.markdown
@@ -1060,11 +1060,11 @@ Where an Xcode project is involved, the organization should be set to `Ray Wende
 
 ## Copyright Statement
 
-The following copyright statement should be included at the top of every source
+The [following copyright statement](LICENSE.txt) should be included at the top of every source
 file:
 
 ```swift
-/// Copyright (c) 2019 Razeware LLC
+/// Copyright 2012-2019 Read It Later, Inc.
 /// 
 /// Permission is hereby granted, free of charge, to any person obtaining a copy
 /// of this software and associated documentation files (the "Software"), to deal
@@ -1075,14 +1075,6 @@ file:
 /// 
 /// The above copyright notice and this permission notice shall be included in
 /// all copies or substantial portions of the Software.
-/// 
-/// Notwithstanding the foregoing, you may not use, copy, modify, merge, publish,
-/// distribute, sublicense, create a derivative work, and/or sell copies of the
-/// Software in any work that is designed, intended, or marketed for pedagogical or
-/// instructional purposes related to programming, coding, application development,
-/// or information technology.  Permission for such use, copying, modification,
-/// merger, publication, distribution, sublicensing, creation of derivative works,
-/// or sale is expressly withheld.
 /// 
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 /// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,


### PR DESCRIPTION
The license used in this pull request is a copy of the license used in other Pocket open source applications, such as the license found [here](https://github.com/Pocket/extension-save-to-pocket/blob/develop/LICENSE).